### PR TITLE
Update types

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -170,14 +170,34 @@
         },
         "username": {
           "type": "string",
-          "description": "Registry username."
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Registry username."
+            },
+            {
+              "type": "array",
+              "description": "Registry username.",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "password": {
-          "type": "array",
-          "description": "Registry password, can be a secret reference.",
-          "items": {
-            "type": "string"
-          }
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Registry password."
+            },
+            {
+              "type": "array",
+              "description": "Registry password.",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
       }
     },
@@ -254,9 +274,9 @@
           "default": "root"
         },
         "port": {
-          "type": "string",
+          "type": "integer",
           "description": "SSH port.",
-          "default": "22"
+          "default": 22
         },
         "proxy": {
           "type": "string",
@@ -330,9 +350,25 @@
               "type": "string",
               "description": "Host to run the accessory on."
             },
+            "hosts": {
+              "type": "array",
+              "description": "List of hosts to run the accessory on.",
+              "items": {
+                "type": "string",
+                "description": "Individual host to run the accessory on."
+              }
+            },
             "port": {
-              "type": "string",
-              "description": "Port mapping for the accessory."
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Port mapping for the accessory."
+                },
+                {
+                  "type": "integer",
+                  "description": "Port mapping for the accessory."
+                }
+              ]
             },
             "cmd": {
               "type": "string",
@@ -377,7 +413,11 @@
               }
             }
           },
-          "required": ["image", "host"]
+          "required": ["image"],
+          "anyOf": [
+            { "required": ["host"] },
+            { "required": ["hosts"] }
+          ]
         }
       },
       "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -170,14 +170,13 @@
         },
         "username": {
           "type": "string",
+          "description": "Registry username.",
           "oneOf": [
             {
-              "type": "string",
-              "description": "Registry username."
+              "type": "string"
             },
             {
               "type": "array",
-              "description": "Registry username.",
               "items": {
                 "type": "string"
               }
@@ -185,14 +184,13 @@
           ]
         },
         "password": {
+          "description": "Registry password.",
           "oneOf": [
             {
-              "type": "string",
-              "description": "Registry password."
+              "type": "string"
             },
             {
               "type": "array",
-              "description": "Registry password.",
               "items": {
                 "type": "string"
               }
@@ -359,14 +357,13 @@
               }
             },
             "port": {
+              "description": "Port mapping for the accessory.",
               "oneOf": [
                 {
-                  "type": "string",
-                  "description": "Port mapping for the accessory."
+                  "type": "string"
                 },
                 {
-                  "type": "integer",
-                  "description": "Port mapping for the accessory."
+                  "type": "integer"
                 }
               ]
             },


### PR DESCRIPTION
Updated types for:
- support multiple types for registry username and password ([according to the docs](https://kamal-deploy.org/docs/configuration/docker-registry/) it can be an array or string)
- change port type to integer (doesn't make sense to have them as strings does it?)
- add hosts array option for accessory configuration (either requires `host` string or `hosts` array)