### PR TITLE
fix: remove unnecessary registry.username field

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -169,7 +169,6 @@
           "description": "Specify the registry server, if you're not using Docker Hub."
         },
         "username": {
-          "type": "string",
           "description": "Registry username.",
           "oneOf": [
             {


### PR DESCRIPTION
I noticed setting the registry username as an array brought up validation errors.

<img width="588" alt="Screenshot 2024-12-19 at 10 00 55 AM" src="https://github.com/user-attachments/assets/954647b8-8321-4ecf-9b30-68d77cf6895e" />

Removing `type` solves the error and seems to work for both strings and arrays